### PR TITLE
Fix for Useless toString on String

### DIFF
--- a/ladybugdb-spring/src/main/java/com/thecookiezen/ladybugdb/spring/config/LadybugDBRepositoryConfigurationExtension.java
+++ b/ladybugdb-spring/src/main/java/com/thecookiezen/ladybugdb/spring/config/LadybugDBRepositoryConfigurationExtension.java
@@ -41,6 +41,6 @@ public class LadybugDBRepositoryConfigurationExtension extends RepositoryConfigu
     @Override
     public void postProcess(BeanDefinitionBuilder builder, RepositoryConfigurationSource source) {
         source.getAttribute("ladybugDBTemplateRef")
-                .ifPresent(ref -> builder.addPropertyReference("template", ref.toString()));
+                .ifPresent(ref -> builder.addPropertyReference("template", ref));
     }
 }


### PR DESCRIPTION
To fix the problem, remove the redundant call to `toString()` on the `ref` variable and pass `ref` directly to `addPropertyReference`. This keeps the behavior the same if `ref` is already a `String` (as expected by the API) and removes unnecessary, noisy code.

Concretely, in `ladybugdb-spring/src/main/java/com/thecookiezen/ladybugdb/spring/config/LadybugDBRepositoryConfigurationExtension.java`, update the `postProcess` method so that line 44 uses `ref` rather than `ref.toString()`. No new imports or additional methods are required, and no other parts of the file need to change. The updated line will be:

```java
.ifPresent(ref -> builder.addPropertyReference("template", ref));
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._